### PR TITLE
Add Flutter mobile starter app and integration analysis for laundry module

### DIFF
--- a/MOBILE_APP_ANALYSIS.md
+++ b/MOBILE_APP_ANALYSIS.md
@@ -1,0 +1,68 @@
+# Flutter Mobile App Analysis for `laundry_management`
+
+## Repository analysis
+
+This repository is an Odoo addon focused on laundry operations:
+
+- Models: orders, contracts, pickup requests, services
+- Views: backend and portal XML views
+- Controllers: web/portal controllers plus JSON-RPC API controller
+
+For mobile integration, the key file is:
+
+- `laundry_management/controllers/api_controller.py`
+
+## Available API endpoints for mobile
+
+1. `/api/login` (POST, JSON-RPC)
+   - Inputs: `db`, `username`, `password`
+   - Returns: `status`, `uid`, `name`, `session_id`
+
+2. `/api/laundry/orders` (GET, JSON-RPC)
+   - Auth required
+   - Returns visible orders list
+
+3. `/api/laundry/order/create` (POST, JSON-RPC)
+   - Auth required
+   - Inputs: `partner_id`, `service_ids`
+
+4. `/api/laundry/order/update` (POST, JSON-RPC)
+   - Auth required
+   - Inputs: `order_id`, `state`
+
+5. `/api/laundry/order/<id>` (GET, JSON-RPC)
+   - Auth required
+   - Returns detailed order payload
+
+## Recommended Flutter architecture
+
+- `data/services/odoo_api_service.dart` for JSON-RPC transport and auth cookie
+- `data/models/` for DTO/model mapping
+- `features/auth/` for login flow
+- `features/orders/` for list/detail/create/update
+- State management: start with `setState`; migrate to Riverpod/Bloc when app grows
+
+## Immediate MVP plan
+
+- Phase 1 (included in this commit as starter code)
+  - Login screen
+  - Orders list screen
+  - Session reuse via `session_id` cookie
+
+- Phase 2
+  - Order detail + pull-to-refresh
+  - Create order form
+  - Update status actions with validation
+
+- Phase 3
+  - Offline cache (Hive/sqflite)
+  - Push notifications
+  - Role-based UI and better error telemetry
+
+## Backend suggestions for smoother mobile integration
+
+- Add versioned routes (`/api/v1/...`).
+- Normalize error envelopes for all methods.
+- Add service catalog endpoint for `service_ids` discovery.
+- Add pagination for orders endpoint.
+- Consider token-based auth in addition to session cookie.

--- a/mobile_app/README.md
+++ b/mobile_app/README.md
@@ -1,0 +1,60 @@
+# Laundry Management Mobile App (Flutter)
+
+This repository is an **Odoo module** (`laundry_management`) with existing JSON-RPC APIs that can be consumed by a Flutter app.
+
+## What already exists in backend
+
+The module exposes these APIs in `laundry_management/controllers/api_controller.py`:
+
+- `POST /api/login`
+- `GET /api/laundry/orders`
+- `POST /api/laundry/order/create`
+- `POST /api/laundry/order/update`
+- `GET /api/laundry/order/<id>`
+
+These are enough to bootstrap an MVP mobile app for:
+
+1. Login
+2. List orders
+3. View order details
+4. Create order
+5. Update order status
+
+## Suggested app scope (Phase 1)
+
+- Authentication with persisted session cookie
+- Orders dashboard
+- Order detail screen
+- Create order screen
+- Basic status update action
+
+## Included starter app
+
+A starter Flutter app is provided under:
+
+`mobile_app/flutter_laundry_app`
+
+It includes:
+
+- JSON-RPC client service
+- Domain model (`LaundryOrder`)
+- Login + Orders UI flow
+- Basic widget test
+
+## How to run
+
+1. Install Flutter SDK.
+2. Start Odoo backend.
+3. Update `baseUrl` in `lib/main.dart` to your server URL.
+4. Run:
+
+```bash
+cd mobile_app/flutter_laundry_app
+flutter pub get
+flutter run
+```
+
+## Notes
+
+- The backend uses `type='jsonrpc'`; requests are sent in JSON-RPC envelope.
+- Session cookies are required after login; this starter includes cookie forwarding logic.

--- a/mobile_app/flutter_laundry_app/analysis_options.yaml
+++ b/mobile_app/flutter_laundry_app/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:flutter_lints/flutter.yaml

--- a/mobile_app/flutter_laundry_app/lib/main.dart
+++ b/mobile_app/flutter_laundry_app/lib/main.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+
+import 'models/laundry_order.dart';
+import 'services/odoo_api_service.dart';
+
+void main() {
+  runApp(const LaundryApp());
+}
+
+class LaundryApp extends StatelessWidget {
+  const LaundryApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Laundry Mobile',
+      theme: ThemeData(useMaterial3: true, colorSchemeSeed: Colors.indigo),
+      home: const LoginPage(),
+    );
+  }
+}
+
+class LoginPage extends StatefulWidget {
+  const LoginPage({super.key});
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final _dbCtrl = TextEditingController(text: 'odoo');
+  final _userCtrl = TextEditingController();
+  final _passCtrl = TextEditingController();
+
+  bool _isLoading = false;
+  String? _error;
+
+  late final OdooApiService _api = OdooApiService(
+    // Replace with your Odoo base URL.
+    baseUrl: 'http://10.0.2.2:8069',
+  );
+
+  Future<void> _login() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+
+    try {
+      await _api.login(
+        db: _dbCtrl.text.trim(),
+        username: _userCtrl.text.trim(),
+        password: _passCtrl.text,
+      );
+
+      if (!mounted) {
+        return;
+      }
+
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(builder: (_) => OrdersPage(api: _api)),
+      );
+    } catch (e) {
+      setState(() {
+        _error = e.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _dbCtrl.dispose();
+    _userCtrl.dispose();
+    _passCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Laundry Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _dbCtrl,
+              decoration: const InputDecoration(labelText: 'Database'),
+            ),
+            TextField(
+              controller: _userCtrl,
+              decoration: const InputDecoration(labelText: 'Username'),
+            ),
+            TextField(
+              controller: _passCtrl,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 16),
+            if (_error != null)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Text(_error!, style: const TextStyle(color: Colors.red)),
+              ),
+            FilledButton(
+              onPressed: _isLoading ? null : _login,
+              child: Text(_isLoading ? 'Signing in...' : 'Login'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class OrdersPage extends StatefulWidget {
+  const OrdersPage({required this.api, super.key});
+
+  final OdooApiService api;
+
+  @override
+  State<OrdersPage> createState() => _OrdersPageState();
+}
+
+class _OrdersPageState extends State<OrdersPage> {
+  late Future<List<LaundryOrder>> _ordersFuture = widget.api.fetchOrders();
+
+  Future<void> _refresh() async {
+    setState(() {
+      _ordersFuture = widget.api.fetchOrders();
+    });
+    await _ordersFuture;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Laundry Orders')),
+      body: FutureBuilder<List<LaundryOrder>>(
+        future: _ordersFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
+
+          final orders = snapshot.data ?? [];
+          if (orders.isEmpty) {
+            return const Center(child: Text('No orders available'));
+          }
+
+          return RefreshIndicator(
+            onRefresh: _refresh,
+            child: ListView.builder(
+              itemCount: orders.length,
+              itemBuilder: (context, index) {
+                final order = orders[index];
+                return ListTile(
+                  title: Text(order.name),
+                  subtitle: Text('${order.customer} • ${order.status}'),
+                  trailing: Text(order.amountTotal.toStringAsFixed(2)),
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/mobile_app/flutter_laundry_app/lib/models/laundry_order.dart
+++ b/mobile_app/flutter_laundry_app/lib/models/laundry_order.dart
@@ -1,0 +1,28 @@
+class LaundryOrder {
+  const LaundryOrder({
+    required this.id,
+    required this.name,
+    required this.customer,
+    required this.status,
+    required this.amountTotal,
+    required this.date,
+  });
+
+  final int id;
+  final String name;
+  final String customer;
+  final String status;
+  final double amountTotal;
+  final String date;
+
+  factory LaundryOrder.fromJson(Map<String, dynamic> json) {
+    return LaundryOrder(
+      id: json['id'] as int,
+      name: json['name'] as String? ?? '',
+      customer: json['customer'] as String? ?? '',
+      status: json['status'] as String? ?? 'draft',
+      amountTotal: (json['amount_total'] as num?)?.toDouble() ?? 0,
+      date: json['date'] as String? ?? '',
+    );
+  }
+}

--- a/mobile_app/flutter_laundry_app/lib/services/odoo_api_service.dart
+++ b/mobile_app/flutter_laundry_app/lib/services/odoo_api_service.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../models/laundry_order.dart';
+
+class OdooApiService {
+  OdooApiService({required this.baseUrl, http.Client? client})
+      : _client = client ?? http.Client();
+
+  final String baseUrl;
+  final http.Client _client;
+
+  String? _sessionId;
+
+  Map<String, String> _headers() {
+    final headers = <String, String>{'Content-Type': 'application/json'};
+    if (_sessionId != null) {
+      headers['Cookie'] = 'session_id=$_sessionId';
+    }
+    return headers;
+  }
+
+  Future<Map<String, dynamic>> _jsonRpcCall({
+    required String path,
+    required Map<String, dynamic> params,
+  }) async {
+    final uri = Uri.parse('$baseUrl$path');
+    final body = jsonEncode({
+      'jsonrpc': '2.0',
+      'method': 'call',
+      'params': params,
+      'id': DateTime.now().millisecondsSinceEpoch,
+    });
+
+    final response = await _client.post(uri, headers: _headers(), body: body);
+    if (response.statusCode != 200) {
+      throw Exception('HTTP ${response.statusCode}: ${response.body}');
+    }
+
+    final decoded = jsonDecode(response.body) as Map<String, dynamic>;
+    if (decoded['error'] != null) {
+      throw Exception(decoded['error'].toString());
+    }
+
+    return decoded['result'] as Map<String, dynamic>;
+  }
+
+  Future<void> login({
+    required String db,
+    required String username,
+    required String password,
+  }) async {
+    final result = await _jsonRpcCall(
+      path: '/api/login',
+      params: {'db': db, 'username': username, 'password': password},
+    );
+
+    if (result['status'] != true) {
+      throw Exception(result['error']?.toString() ?? 'Login failed');
+    }
+
+    _sessionId = result['session_id']?.toString();
+    if (_sessionId == null || _sessionId!.isEmpty) {
+      throw Exception('Missing session id from login response');
+    }
+  }
+
+  Future<List<LaundryOrder>> fetchOrders() async {
+    final result = await _jsonRpcCall(path: '/api/laundry/orders', params: {});
+    if (result['status'] != true) {
+      throw Exception(result['error']?.toString() ?? 'Could not fetch orders');
+    }
+
+    final orders = (result['orders'] as List<dynamic>? ?? [])
+        .cast<Map<String, dynamic>>()
+        .map(LaundryOrder.fromJson)
+        .toList();
+    return orders;
+  }
+}

--- a/mobile_app/flutter_laundry_app/pubspec.yaml
+++ b/mobile_app/flutter_laundry_app/pubspec.yaml
@@ -1,0 +1,20 @@
+name: flutter_laundry_app
+description: Flutter mobile client for the laundry_management Odoo module
+publish_to: 'none'
+version: 0.1.0+1
+
+environment:
+  sdk: '>=3.3.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^1.2.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.0
+
+flutter:
+  uses-material-design: true

--- a/mobile_app/flutter_laundry_app/test/widget_test.dart
+++ b/mobile_app/flutter_laundry_app/test/widget_test.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('sanity test renders material app', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: Scaffold(body: Text('ok'))));
+
+    expect(find.text('ok'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
### Motivation
- Provide a small, opinionated Flutter starter app that consumes the existing Odoo JSON-RPC endpoints exposed by the `laundry_management` module so a mobile MVP can be bootstrapped quickly. 
- Document the backend API surface and a phased roadmap to guide mobile integration and future backend improvements. 
- Used the `skill-creator` guidance to scaffold the app and map the integration approach.

### Description
- Added `MOBILE_APP_ANALYSIS.md` which analyzes the repo, enumerates available endpoints, recommends architecture, and proposes a phased MVP roadmap. 
- Added `mobile_app/README.md` with instructions for running the starter app and a summary of available backend endpoints. 
- Added a Flutter starter app at `mobile_app/flutter_laundry_app` including `pubspec.yaml` and `analysis_options.yaml`. 
- Implemented a minimal UI and client: `lib/main.dart` (login + orders flow), `lib/services/odoo_api_service.dart` (JSON-RPC transport with `session_id` cookie handling), and `lib/models/laundry_order.dart` (order DTO). 
- Included a basic widget test at `test/widget_test.dart` to serve as a sanity check for Flutter integration.

### Testing
- Ran repository checks (`git status --short`, file listing) to validate created files; these succeeded. 
- Attempted to detect Flutter with `flutter --version`, which failed because the Flutter SDK is not available in this environment. 
- Attempted an automated Playwright check against `http://localhost:8069`, which failed with `ERR_EMPTY_RESPONSE` because no backend was reachable in this environment. 
- No Flutter tests (`flutter test`) were run because the runtime/SDK is not installed here; the provided `test/widget_test.dart` is included for local execution once Flutter is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698af484e1b08320bb7bd99560e94972)